### PR TITLE
Pointed title to new domain.

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -8,7 +8,7 @@
       <span class="icon-bar"></span>
     </button>
     <div id="site-title">
-      <a href="http://gamma.library.temple.edu/gencon50">Best <span class="futura">50</span> Years in Gaming</a>
+      <a href="http://www.best50yearsingaming.com">Best <span class="futura">50</span> Years in Gaming</a>
       <p style="font-size: smaller;">The events of the Gen Con Gaming Convention</p>
     </div>
     </div>


### PR DESCRIPTION
Title still linked to Gamma. Changed to point to best50yearsingaming.com.